### PR TITLE
Add Repl Command to exit (':q')

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -409,6 +409,9 @@ var nodeRepl = function() {
         var compiled;
         var output;
         try {
+            if (line.replace(/^\s+/g,"").replace(/\s+$/g,"") == ":q"){
+                process.exit();
+            }
             compiled = compile(line, env);
             output = vm.runInNewContext(compiled.output, sandbox, 'eval');
             if(typeof output != 'undefined') console.log(output + " : " + compiled.type);


### PR DESCRIPTION
Roy Repl have only two command "CTRL + C" or "prosess.exit()" to quit.
I think we should add commands to Repl haskell-like ":q" and I fix it so.

How do you think?
