### PR TITLE
Implement unicode identifiers.

### DIFF
--- a/lib/std.roy
+++ b/lib/std.roy
@@ -13,6 +13,13 @@ let odd a = not (even a)
 let succ n = n + 1
 let pred n = n - 1
 
+//let compose f g = λx → f (g x)
+//let ∘ = compose
+//let elem =
+//let ∈ = elem
+//let ∉ = not ∘ elem
+//let negate n = -n
+
 // List type
 
 // data List a = Cons a (List a) | Nil
@@ -80,6 +87,7 @@ let optionMonad = {
 data Either a b = Left a | Right b
 
 // Math constants.
-//let π = Math.PI
-//let π2 = π * 2
-//let τ = π2  // tauday.com
+let π = Math.PI
+let π2 = π * 2
+// tauday.com
+let τ = π2

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "homepage": "http://roy.brianmckenna.org/",
   "dependencies": {
     "jison": ">= 0.2.x",
-    "underscore": ">= 1.2.0"
+    "underscore": ">= 1.2.0",
+    "unicode-categories": "0.9.0"
   },
   "devDependencies": {
     "interleave": ">= 0.0.6"

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -1,4 +1,15 @@
-var IDENTIFIER = /^[a-zA-Z$_][a-zA-Z0-9$_]*/;
+var unicode = require('unicode-categories');
+
+// http://es5.github.com/#x7.6
+// ECMAscript identifier starts with `$`, `_`,
+// or letter from (Lu Ll Lt Lm Lo Nl) unicode groups.
+// Then identifier can also be from groups (Nd, Mn, Mc, or Pc).
+// Roy identifier cannot have letter u03BB (greek lowercase lambda)
+// because it's used in anonymous functions.
+var IDENTIFIER = new RegExp(
+    unicode.ECMA.identifier.source.replace('\\u03BB', '')
+);
+
 var NUMBER = /^-?[0-9]+(\.[0-9]+)?/;
 var COMMENT = /^\/\/.*/;
 var WHITESPACE = /^[^\n\S]+/;

--- a/test/unicode.out
+++ b/test/unicode.out
@@ -5,3 +5,4 @@ Binding: 3
 Binding: 4
 Return: 10
 10
+test

--- a/test/unicode.roy
+++ b/test/unicode.roy
@@ -24,3 +24,6 @@ console.log (do traceMonad
   z <- 4
   return w + x + y + z
 )
+
+let тест = "test"
+console.log тест


### PR DESCRIPTION
This adds unicode identifiers support. 

As in [ES5 7.6](http://es5.github.com/#x7.6), ECMAscript identifier starts with `$`, `_`, or letter from (Lu Ll Lt Lm Lo Nl) unicode groups.

Then identifier can also be from groups (Nd, Mn, Mc, or Pc).

Roy identifier cannot have letter u03BB (greek lowercase lambda) because it's used in anonymous functions.

As an example, roy's std lib now has three math constants:

``` roy
let π = Math.PI
let π2 = π * 2
// tauday.com
let τ = π2
```

It's implemented using my [unicode-categories](https://github.com/paulmillr/unicode-categories) library.

CoffeeScript also has this problem, see jashkenas/coffee-script#1718.

Related: #47.
