### PR TITLE
Fixed bundling failure due to missing prettyprint module.

### DIFF
--- a/interleaved-roy.js
+++ b/interleaved-roy.js
@@ -35,6 +35,9 @@ var roy = {};
     load["./types"] = function(exports) {
         //= src/types.js
     };
+    load["./prettyprint"] = function (exports) {
+        //= src/prettyprint.js
+    };
 
     roy.lexer = require("./lexer");
     roy.compile = require("./compile").compile;


### PR DESCRIPTION
Just added a reference to the prettyprint module in the interleaved entry point file.
