### PR TITLE
Fix lexer for token ||

### DIFF
--- a/src/grammar.js
+++ b/src/grammar.js
@@ -7,6 +7,7 @@ var grammar = {
     "operators": [
         ["left", "RIGHTARROW", "LEFTARROW", "RIGHTFATARROW", "ELEM", "NOTELEM",
           "FORALL", "COMPOSE"],
+        ["right", "IF", "ELSE"],
         ["left", "BOOLOP"],
         ["left", "COMPARE", "WITH"],
         ["left", "+", "-", "!"],
@@ -94,7 +95,8 @@ var grammar = {
             ["patternIdentifiers identifier", "$$ = $1; $1.push($2);"]
         ],
         "ifThenElse": [
-            ["IF innerExpression THEN block TERMINATOR ELSE block", "$$ = new yy.IfThenElse($2, $4, $7);"]
+            ["IF innerExpression THEN block TERMINATOR ELSE block", "$$ = new yy.IfThenElse($2, $4, $7);"],
+            ["IF innerExpression THEN innerExpression ELSE innerExpression", "$$ = new yy.IfThenElse($2, [$4], [$6]);"]
         ],
 
         // data Maybe a = Some a | None

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -183,6 +183,9 @@ var literalToken = function() {
         case '|]':
             tokens.push([next, next, lineno]);
             return 2;
+        case '||':
+            tokens.push(['BOOLOP', next, lineno]);
+            return 2;
         }
         tokens.push([tag, tag, lineno]);
         return 1;
@@ -211,14 +214,6 @@ var literalToken = function() {
     case '&':
         next = chunk.slice(0, 2);
         if(next == '&&') {
-            tokens.push(['BOOLOP', next, lineno]);
-            return 2;
-        }
-        tokens.push([tag, tag, lineno]);
-        return 1;
-    case '|':
-        next = chunk.slice(0, 2);
-        if(next == '||') {
             tokens.push(['BOOLOP', next, lineno]);
             return 2;
         }

--- a/test/conditionals.out
+++ b/test/conditionals.out
@@ -1,0 +1,4 @@
+ok
+ok
+ok
+ok

--- a/test/conditionals.roy
+++ b/test/conditionals.roy
@@ -1,0 +1,9 @@
+let x = if 2 > 0 then
+  "ok"
+else
+  "fail"
+console.log(x)
+
+console.log(if 2 > 0 then "ok" else "fail")
+console.log(if 3 > 0 then if 3 < 0 then "fail" else "ok" else "fail")
+console.log(if 3 < 0 then "fail" else if 3 > 0 then "ok2" else "fail")


### PR DESCRIPTION
The first case of '|' for macros overrides the '|' for OR (||).

By the way, I haven't used macros yet, but it seems that 19218e4a broke them, `examples/macro.roy` does not compile.
