### PR TITLE
Fixed type inference of pattern variable

### DIFF
--- a/src/typeinference.js
+++ b/src/typeinference.js
@@ -449,8 +449,8 @@ var analyse = function(node, env, nonGeneric, data, aliases) {
                                 if(v.value in data) {
                                     unify(currentValue, fresh(prune(newEnv[v.value]), newNonGeneric));
                                 } else {
-                                    newEnv[v.value] = currentValue;
-                                    newNonGeneric.push(newEnv[v.value]);
+                                    newEnv[v.value] = data[p.tag.value][i];
+                                    newNonGeneric.push(currentValue);
                                 }
                                 argNames[v.value] = newEnv[v.value];
                             },

--- a/test/deep_matching.roy
+++ b/test/deep_matching.roy
@@ -8,3 +8,10 @@ console.log (xor (Left (Left 100)))
 console.log (xor (Left (Right 100)))
 console.log (xor (Right (Left 100)))
 console.log (xor (Right (Right 100)))
+
+data XX = X
+data YY = Y XX
+let yy = Y X
+let idXX (x:XX) = x
+match yy
+  case (Y x) = idXX x


### PR DESCRIPTION
### Problem

Failed to infer types of variables in deep pattern matches.
### Sample Code

```
data XX = X
data YY = Y XX
let yy = Y X
let idXX (x:XX) = x
match yy
  case (Y x) = idXX x
```
### Expected

Compiled without error.
### Actual

```
Type error: YY is not XX
```
### Cause

in addVarsToEnv:

```
newEnv[v.value] = currentValue;
```

newEnv[v.value] should be the type of the variable but currentValue is the type of the pattern.
data[p.tag.value][i] is the expected type from data constructor.
### Fix

Assign data[p.tag.value][i] instead of currentValue to newEnv[v.value].
