### PR TITLE
Module Loader Tolerant of Missing Modules

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -23,8 +23,14 @@ var resolveNodeModule = function(moduleName, filename) {
 
 exports.loadModule = function(moduleName, opts) {
     if(!opts.modules) opts.modules = {};
-    var source = opts.modules[moduleName] || require('fs').readFileSync(resolveNodeModule(moduleName, opts.filename) + '.roym', 'utf8');
-
+    var path = require('path'),
+        targetFile = resolveNodeModule(moduleName, opts.filename) + '.roym',
+        source = '';
+    
+    if (path.existsSync(targetFile)) {
+        source = opts.modules[moduleName] || require('fs').readFileSync(targetFile, 'utf8');
+    }
+    
     var tokens = lexer.tokenise(source);
     var moduleTypes = typeparser.parse(tokens);
     return moduleTypes;


### PR DESCRIPTION
Hey Brian,

Not sure if this is the exact behaviour you will be wanting in roy, but it was a little confusing that I couldn't run roy in normal mode (i.e. generate JS) without the prelude.roym file in the lib path.  

Once I ran it in non-generate mode that file was created, though it will probably be helpful if roy generated a warning rather than falling over.

Anyway, take a look.  If you think it's helpful great, if not inline with the way you want it to behave, then I'm not offended :)

Cheers,
Damon.
