### PR TITLE
Implicit extensions when loading with :l

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -662,6 +662,7 @@ var main = function() {
         console.log(info.version);
         process.exit();
         break;
+    case "--help":
     case "-h":
         console.log("Roy: " + info.description + "\n");
         console.log("-v        : show current version");

--- a/src/compile.js
+++ b/src/compile.js
@@ -508,7 +508,13 @@ var nodeRepl = function(opts) {
             case ":l":
                 // Load
                 filename = metacommand[1];
-                source = fs.readFileSync(filename, 'utf8');
+
+                try {
+                  source = fs.readFileSync(filename, 'utf8');
+                } catch (e) {
+                  source = fs.readFileSync(filename + '.roy', 'utf8');
+                }
+
                 compiled = compile(source, env, aliases, {nodejs: true, filename: ".", run: true});
                 break;
             case ":t":


### PR DESCRIPTION
A few minor usability changes:
- Added --help alias for -h
- :l will try to load filename{.roy, lroy} if the first attempt fails
