### PR TITLE
Fix minor bugs on statements

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -236,7 +236,7 @@ var compileNodeWithEnv = function(n, env, opts) {
             }
             return "(function(){\n" + pushIndent() + "var __monad__ = " +
                 compileNode(n.value) + ";\n" + getIndent() +
-                (!firstBind ? 'return ' : '') + compiledInit.join('\n' + getIndent()) +
+                (!firstBind ? 'return ' : '') + compiledInit.join(';\n' + getIndent()) + '\n' + getIndent() +
                 (firstBind ? 'return ' + compileNode(firstBind) : '') + "\n" +
                 popIndent() + "})()";
         },

--- a/src/typeinference.js
+++ b/src/typeinference.js
@@ -333,13 +333,20 @@ var analyse = function(node, env, nonGeneric, aliases, constraints) {
             return functionType;
         },
         visitIfThenElse: function() {
+            // if statements are compiled into (function() {...})(), thus they introduce a new environment.
+            var newEnv = _.clone(env);
+
+            var conditionType = analyse(node.condition, newEnv, nonGeneric, aliases, constraints);
+
+            unify(conditionType, new t.BooleanType(), node.condition.lineno);
+
             var ifTrueScopeTypes = _.map(withoutComments(node.ifTrue), function(expression) {
-                return analyse(expression, env, nonGeneric, aliases, constraints);
+                return analyse(expression, newEnv, nonGeneric, aliases, constraints);
             });
             var ifTrueType = ifTrueScopeTypes[ifTrueScopeTypes.length - 1];
 
             var ifFalseScopeTypes = _.map(withoutComments(node.ifFalse), function(expression) {
-                return analyse(expression, env, nonGeneric, aliases, constraints);
+                return analyse(expression, newEnv, nonGeneric, aliases, constraints);
             });
             var ifFalseType = ifFalseScopeTypes[ifFalseScopeTypes.length - 1];
 


### PR DESCRIPTION
### Problem 1: Conditions of if expressions are not type checked.

The following code should raise type error but not.

```
if 1 + 1 then 1 else 1
```

We must infer the type and unify it with Boolean type.
### Problem 2: If expressions does not introduce new environment.

The following code

```
let x = true
if true then
  let x = 2
  1
else
  1

console.log(x + 1)
```

which is compiled into

```
var x = true;
(function() {
    if(true) {
        var x = 2;
        return 1;
    } else {
        return 1;
    }
})();
console.log((x + 1));
```

should raise type error, but not.

If expressions are compiled into function, so that they introduce new environments.
Thus, we must also introduce new environments in the type inferer.
### Problem 3: Missing \n after inits of do expression

The following code

```
let identityMonad = {
  return: \x -> x
  bind: \m f -> f m
}

do identityMonad
  let x = 1
  let y = 1
  z <- 1
  return 1
```

is compiled into

```
...

var __monad__ = identityMonad;
var x = 1
var y = 1return __monad__.bind(1, function(z) {

    return __monad__.return(1);
});

...
```

\n is missing after “var y = 1”.
