### PR TITLE
Fixes for loading files in the REPL

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -491,7 +491,7 @@ var getSandbox = function() {
     return sandbox;
 };
 
-var getFileContents = function(filename) {
+var getFileContents = function(filename, fs) {
     var path = require('path'),
         exts = ["", ".roy", ".lroy"],
         filenames = _.map(exts, function(ext){
@@ -575,7 +575,7 @@ var nodeRepl = function(opts) {
             case ":l":
                 // Load
                 filename = metacommand[1];
-                source = getFileContents(filename);
+                source = getFileContents(filename, fs);
                 compiled = compile(source, env, aliases, {nodejs: true, filename: ".", run: true});
                 break;
             case ":t":

--- a/src/compile.js
+++ b/src/compile.js
@@ -491,8 +491,8 @@ var getSandbox = function() {
     return sandbox;
 };
 
-var getFileContents = function(filename, fs) {
-    var path = require('path'),
+var getFileContents = function(filename) {
+    var fs = require('fs'),
         exts = ["", ".roy", ".lroy"],
         filenames = _.map(exts, function(ext){
             return filename + ext;
@@ -508,7 +508,7 @@ var getFileContents = function(filename, fs) {
         filenames = [filename];
     } else {
         findfilename = _.find(filenames, function(filename) {
-            return path.existsSync(filename);
+            return fs.existsSync(filename);
         });
         if (findfilename) {
             source = fs.readFileSync(findfilename, 'utf8');
@@ -579,7 +579,7 @@ var nodeRepl = function(opts) {
             case ":l":
                 // Load
                 filename = metacommand[1];
-                source = getFileContents(filename, fs);
+                source = getFileContents(filename);
                 compiled = compile(source, env, aliases, {nodejs: true, filename: ".", run: true});
                 break;
             case ":t":

--- a/src/compile.js
+++ b/src/compile.js
@@ -507,9 +507,13 @@ var getFileContents = function(filename, fs) {
         source = fs.readFileSync(filename, 'utf8');
         filenames = [filename];
     } else {
-        source = _.find(filenames, function(filename) {
+        findfilename = _.find(filenames, function(filename) {
             return path.existsSync(filename);
         });
+        if (findfilename) {
+            source = fs.readFileSync(findfilename, 'utf8');
+            filenames = [findfilename];
+        }
     }
 
     if(source == null) {


### PR DESCRIPTION
Fixed `ReferenceError: fs is not defined` when loading a file wile extension into the REPL.

Fixed code to try common file extensions when loading file into the REPL without an extension.

I'm not sure if I was just doing something wrong, but this fixed my problem for me. If it helps you and others, great.
