### PR TITLE
Supplied Interleave Build Command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ deps:
 	npm prune
 
 bundle:
-	./node_modules/interleave/bin/interleave interleaved-roy.js
+	./node_modules/interleave/bin/interleave build interleaved-roy.js
 
 site: all bundle
 	[ -e roy.brianmckenna.org ] || mkdir roy.brianmckenna.org


### PR DESCRIPTION
Hey Brian,

Interleave 0.5.x is build more command driven, so the existing bundle command didn't perform the expected behaviour and also failed silently.  I'm going to deal with this in Interleave so running something like `interleave <targetfile>` actually works, but for the current version I've fixed the Makefile.

Cheers,
Damon.
