### PR TITLE
Correct the lib/*.js paths in rigger-roy.js.

### DIFF
--- a/rigger-roy.js
+++ b/rigger-roy.js
@@ -32,10 +32,10 @@ var roy = {};
     load["./macroexpand"] = function(exports) {
         //= src/macroexpand.js
     };
-    load["./typeparser"] = function(exports) {
+    load["../lib/typeparser"] = function(exports) {
         //= lib/typeparser.js
     };
-    load["./parser"] = function(exports) {
+    load["../lib/parser"] = function(exports) {
         //= lib/parser.js
     };
     load["./typeinference"] = function(exports) {


### PR DESCRIPTION
Various files require `../lib/parser`, as they should, and not `./parser`. Same goes for typeparser. Let's include these correctly in the rigged version of Roy.
