### PR TITLE
Chrome 23 refuses to load Rome extension

### DIFF
--- a/misc/chrome-extension/add-compile-listener.js
+++ b/misc/chrome-extension/add-compile-listener.js
@@ -1,0 +1,9 @@
+chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
+  var js;
+  try {
+    js = roy.compile(request.code).output;
+  } catch(e) {
+    js = e.toString();
+  }
+  sendResponse({js: js});
+});

--- a/misc/chrome-extension/background.htm
+++ b/misc/chrome-extension/background.htm
@@ -2,16 +2,6 @@
 <html>
   <head>
     <script src="roy-min.js"></script>
-    <script>
-      chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
-        var js;
-        try {
-          js = roy.compile(request.code).output;
-        } catch(e) {
-          js = e.toString();
-        }
-        sendResponse({js: js});
-      });
-    </script>
+    <script src="add-compile-listener.js"></script>
   </head>
 </html>

--- a/misc/chrome-extension/manifest.json
+++ b/misc/chrome-extension/manifest.json
@@ -1,12 +1,13 @@
 {
   "name": "Rome - Roy Compiler",
   "version": "0.1",
+  "manifest_version": 2,
   "description": "Compiles and executes local Roy files.",
 
   "icons": { "16": "roy_16.png",
              "48": "roy_48.png",
              "128": "roy_128.png" },
-  "background_page": "background.htm",
+  "background": { "page": "background.htm" },
   "content_scripts": [
     {
       "matches": ["file:///*/*.roy"],


### PR DESCRIPTION
The Rome extension cannot be loaded in Chrome 23 because it uses the older manifest format, which is deprecated. It also uses an inline script, which is not allowed under the [default security policy](http://developer.chrome.com/trunk/extensions/contentSecurityPolicy.html) for Manifest V2.
