### PR TITLE
Fix Roy tests on Node.js 0.10

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -86,7 +86,12 @@ module.exports = function(grunt) {
             done(true);
         };
 
-        jasmine.executeSpecsInFolder(specDir, onComplete, false, true);
+        jasmine.executeSpecsInFolder({
+            'specFolders': [specDir],
+            'onComplete': onComplete,
+            'isVerbose': false,
+            'showColors': true
+        });
     });
 
     grunt.registerTask('default', 'jison lint jasmine rigger min');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "grunt": "0.3.15",
     "rigger": "0.3.19",
-    "jasmine-node": "1.0.26"
+    "jasmine-node": "1.5.0"
   }
 }


### PR DESCRIPTION
jasmine-node 1.0.26 contains a comparison on the Node.js version string that expects the minor release number to be a single digit.  This obviously breaks with Node.js 0.10, so I updated Roy to use the latest version of jasmine-node (1.5.0).
