### PR TITLE
Wrap Identifier / Literal with ExpressionStatement

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -31,7 +31,7 @@ parser.lexer = typeparser.lexer =  {
 };
 
 var ensureJsASTStatement = function (node) {
-    if (/Expression$/.test(node.type)) {
+    if (/Expression$/.test(node.type) || node.type === 'Identifier' || node.type === 'Literal') {
         return { type: "ExpressionStatement", expression: node };
     }
     return node;

--- a/test/CompileSpec.js
+++ b/test/CompileSpec.js
@@ -41,6 +41,16 @@ describe('compiler', function(){
         expect(compilerOutput('// HELLO\nconsole.log 123')).toEqual('// HELLO\nconsole.log(123);');
     });
 
+    it('should compile literal', function(){
+        expect(compilerOutput('42')).toEqual('42;');
+        expect(compilerOutput('\'string\'')).toEqual('\'string\';');
+        expect(compilerOutput('null')).toEqual('null;');
+    });
+
+    it('should compile identifier', function(){
+        expect(compilerOutput('roy')).toEqual('roy;');
+    });
+
     it('should only execute a match expression once', function(){
         expectExecutionToHaveExpectedOutput('good/match_expression_single_eval');
     });


### PR DESCRIPTION
Wrap `Identifier` and `Literal` with ExpressionStatement.
#178 is solved by this commit.
