### PR TITLE
Lexer refactor

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -264,19 +264,11 @@ var shebangToken = function(chunk) {
     return 0;
 };
 
-exports.tokenise = function(source) {
+var tokenise = function(source, tokenizers) {
     /*jshint boss:true*/
-    indent = 0;
-    indents = [];
-    tokens = [];
-    lineno = 0;
     var i = 0, chunk;
 
     function getDiff(chunk) {
-        var tokenizers = [identifierToken, numberToken,
-            stringToken, genericToken, commentToken, whitespaceToken,
-            lineToken, literalToken, shebangToken];
-
         return _.foldl(tokenizers, function(diff, tokenizer) {
             return diff ? diff : tokenizer.apply(tokenizer, [chunk]);
         }, 0);
@@ -290,6 +282,18 @@ exports.tokenise = function(source) {
         lineno += source.slice(i, i + diff).split('\n').length - 1;
         i += diff;
     }
-    tokens.push(['EOF', '', lineno]);
+
     return tokens;
+};
+
+exports.tokenise = function(source) {
+    indent = 0;
+    indents = [];
+    tokens = [];
+    lineno = 0;
+    
+    return tokenise(source, [identifierToken, numberToken,
+            stringToken, genericToken, commentToken, whitespaceToken,
+            lineToken, literalToken, shebangToken]
+            ).concat([['EOF', '', lineno]]);
 };

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -118,7 +118,6 @@ var lineToken = function() {
     if(token) {
         var lastNewline = token[0].lastIndexOf("\n") + 1;
         var size = token[0].length - lastNewline;
-        var terminated = false;
         if(size > indent) {
             indents.push(size);
             tokens.push(['INDENT', size - indent, lineno]);

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -18,6 +18,26 @@ var INDENT = /^(?:\n[^\n\S]*)+/;
 var GENERIC = /^#([a-z]+)/;
 var SHEBANG = /^#!.*/;
 
+var keywordTokens = {
+    'true':      'BOOLEAN',
+    'false':     'BOOLEAN',
+    'Function':  'FUNCTION',
+    'let':       'LET',
+    'if':        'IF',
+    'instance':  'INSTANCE',
+    'then':      'THEN',
+    'else':      'ELSE',
+    'data':      'DATA',
+    'type':      'TYPE',
+    'typeclass': 'TYPECLASS',
+    'match':     'MATCH',
+    'case':      'CASE',
+    'do':        'DO',
+    'return':    'RETURN',
+    'with':      'WITH',
+    'where':     'WHERE'
+};
+
 var chunk;
 var indent;
 var indents;
@@ -25,37 +45,12 @@ var tokens;
 var lineno;
 
 var identifierToken = function() {
-    var value,
-        name,
-        token = IDENTIFIER.exec(chunk);
+    var token = IDENTIFIER.exec(chunk);
+
     if(token) {
-        value = token[0];
-        switch(value) {
-        case 'true':
-        case 'false':
-            name = 'BOOLEAN';
-            break;
-        case 'Function':
-        case 'let':
-        case 'if':
-        case 'instance':
-        case 'then':
-        case 'else':
-        case 'data':
-        case 'type':
-        case 'typeclass':
-        case 'match':
-        case 'case':
-        case 'do':
-        case 'return':
-        case 'with':
-        case 'where':
-            name = value.toUpperCase();
-            break;
-        default:
-            name = 'IDENTIFIER';
-            break;
-        }
+        var value = token[0],
+            name = keywordTokens[value] || 'IDENTIFIER';
+
         tokens.push([name, value, lineno]);
         return token[0].length;
     }

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -38,13 +38,12 @@ var keywordTokens = {
     'where':     'WHERE'
 };
 
-var chunk;
 var indent;
 var indents;
 var tokens;
 var lineno;
 
-var identifierToken = function() {
+var identifierToken = function(chunk) {
     var token = IDENTIFIER.exec(chunk);
 
     if(token) {
@@ -57,7 +56,7 @@ var identifierToken = function() {
     return 0;
 };
 
-var numberToken = function() {
+var numberToken = function(chunk) {
     var token = NUMBER.exec(chunk);
     if(token) {
         tokens.push(['NUMBER', token[0], lineno]);
@@ -66,7 +65,7 @@ var numberToken = function() {
     return 0;
 };
 
-var stringToken = function() {
+var stringToken = function(chunk) {
   var token = STRING.exec(chunk);
   if (token) {
     tokens.push(['STRING', token[0], lineno]);
@@ -76,7 +75,7 @@ var stringToken = function() {
   return 0;
 };
 
-var genericToken = function() {
+var genericToken = function(chunk) {
     var token = GENERIC.exec(chunk);
     if(token) {
         tokens.push(['GENERIC', token[1], lineno]);
@@ -85,7 +84,7 @@ var genericToken = function() {
     return 0;
 };
 
-var commentToken = function() {
+var commentToken = function(chunk) {
     var token = COMMENT.exec(chunk);
     if(token) {
         tokens.push(['COMMENT', token[0], lineno]);
@@ -94,7 +93,7 @@ var commentToken = function() {
     return 0;
 };
 
-var whitespaceToken = function() {
+var whitespaceToken = function(chunk) {
     var token = WHITESPACE.exec(chunk);
     if(token) {
         return token[0].length;
@@ -108,7 +107,7 @@ var lineContinuer = {
     "where": true
 };
 
-var lineToken = function() {
+var lineToken = function(chunk) {
     var token = INDENT.exec(chunk);
     if(token) {
         var lastNewline = token[0].lastIndexOf("\n") + 1;
@@ -133,13 +132,14 @@ var lineToken = function() {
                 }
             }
         }
+
         indent = size;
         return token[0].length;
     }
     return 0;
 };
 
-var literalToken = function() {
+var literalToken = function(chunk) {
     var tag = chunk.slice(0, 1);
     var next;
     switch(tag) {
@@ -254,7 +254,7 @@ var literalToken = function() {
     return 0;
 };
 
-var shebangToken = function() {
+var shebangToken = function(chunk) {
     var token = SHEBANG.exec(chunk);
     if (token) {
         tokens.push(['SHEBANG', token[0], lineno]);
@@ -269,9 +269,9 @@ exports.tokenise = function(source) {
     indents = [];
     tokens = [];
     lineno = 0;
-    var i = 0;
+    var i = 0, chunk;
     while(chunk = source.slice(i)) {
-        var diff = identifierToken() || numberToken() || stringToken() || genericToken() || commentToken() || whitespaceToken() || lineToken() || literalToken() || shebangToken();
+        var diff = identifierToken(chunk) || numberToken(chunk) || stringToken(chunk) || genericToken(chunk) || commentToken(chunk) || whitespaceToken(chunk) || lineToken(chunk) || literalToken(chunk) || shebangToken(chunk);
         if(!diff) {
             throw "Couldn't tokenise: " + chunk.substring(0, chunk.indexOf("\n") > -1 ? chunk.indexOf("\n") : chunk.length);
         }

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -1,4 +1,5 @@
-var unicode = require('unicode-categories');
+var unicode = require('unicode-categories'),
+    _ = require('underscore');
 
 // http://es5.github.com/#x7.6
 // ECMAscript identifier starts with `$`, `_`,
@@ -270,8 +271,19 @@ exports.tokenise = function(source) {
     tokens = [];
     lineno = 0;
     var i = 0, chunk;
+
+    function getDiff(chunk) {
+        var tokenizers = [identifierToken, numberToken,
+            stringToken, genericToken, commentToken, whitespaceToken,
+            lineToken, literalToken, shebangToken];
+
+        return _.foldl(tokenizers, function(diff, tokenizer) {
+            return diff ? diff : tokenizer.apply(tokenizer, [chunk]);
+        }, 0);
+    }
+
     while(chunk = source.slice(i)) {
-        var diff = identifierToken(chunk) || numberToken(chunk) || stringToken(chunk) || genericToken(chunk) || commentToken(chunk) || whitespaceToken(chunk) || lineToken(chunk) || literalToken(chunk) || shebangToken(chunk);
+        var diff = getDiff(chunk);
         if(!diff) {
             throw "Couldn't tokenise: " + chunk.substring(0, chunk.indexOf("\n") > -1 ? chunk.indexOf("\n") : chunk.length);
         }


### PR DESCRIPTION
Refactored lexer in support of removing `let` (which is almost there; 1 failing test cases remaining due to `where`).

The main changes are:
1. Put the keywords in a map, so we can easily check if something is a keyword or not by checking its presence in the map.
2. Parameterize the tokenize functions on `chunk`, so we can process a substring of `chunk` instead of the whole thing.
3. Pull out a `tokenise` function that can be used outside the main `exports.tokenise`.

This is a big enough change to a critical piece of code that I figured a PR would be appropriate.
