### PR TITLE
Add comment support at end of line

### DIFF
--- a/src/grammar.js
+++ b/src/grammar.js
@@ -33,6 +33,8 @@ var grammar = {
         "line": [
             ["statement", "$$ = $1;"],
             ["expression", "$$ = $1;"],
+            ["statement COMMENT", "$$ = $1;"],
+            ["expression COMMENT", "$$ = $1;"],
             ["COMMENT", n("$$ = new yy.Comment($1);")]
         ],
         "block": [


### PR DESCRIPTION
Unlike a whole comment line. A trailing comment does not appear in the
javascript source. That should be fixable but less urgent
