### PR TITLE
multiline object type aliases

### DIFF
--- a/src/typegrammar.js
+++ b/src/typegrammar.js
@@ -34,8 +34,23 @@ var bnf = {
     ],
     "optTypePairs": [
         ["", "$$ = {};"],
+        ["typePairs", "$$ = $1"],
+        ["INDENT typePairs OUTDENT TERMINATOR", "$$ = $2;"]
+    ],
+    "typePairs": [
         ["keywordOrIdentifier : type", "$$ = {}; $$[$1] = $3;"],
-        ["optTypePairs , keywordOrIdentifier : type", "$$ = $1; $1[$3] = $5;"]
+        ["typePairs , keywordOrIdentifier : type", "$$ = $1; $1[$3] = $5;"],
+        ["typePairs TERMINATOR optTerm keywordOrIdentifier : type", "$$ = $1; $1[$4] = $6;"],
+        ["STRING : type", "$$ = {}; $$[$1] = $3;"],
+        ["typePairs , STRING : type", "$$ = $1; $1[$3] = $5;"],
+        ["typePairs TERMINATOR optTerm STRING : type", "$$ = $1; $1[$4] = $6;"],
+        ["NUMBER : type", "$$ = {}; $$[$1] = $3;"],
+        ["typePairs , NUMBER : type", "$$ = $1; $1[$3] = $5;"],
+        ["typePairs TERMINATOR optTerm NUMBER : type", "$$ = $1; $1[$4] = $6;"]
+    ],
+    "optTerm": [
+        ["", ""],
+        ["TERMINATOR", ""]
     ],
     "dataParamList": [
         ["IDENTIFIER", "$$ = [new yy.Arg($1)];"],
@@ -87,6 +102,8 @@ var grammar = {
         "optTypeFunctionArgList": bnf.optTypeFunctionArgList,
         "typeFunctionArgList": bnf.typeFunctionArgList,
         "optTypePairs": bnf.optTypePairs,
+        "typePairs": bnf.typePairs,
+        "optTerm": bnf.optTerm,
         "dataParamList": bnf.dataParamList,
         "optDataParamList": bnf.optDataParamList,
         "keywordOrIdentifier": bnf.keywordOrIdentifier

--- a/test/CompileSpec.js
+++ b/test/CompileSpec.js
@@ -87,6 +87,9 @@ describe('compiler', function(){
         it('object.roy with expected output', function() {
             expectExecutionToHaveExpectedOutput('good/object');
         });
+        it('typesynonym.roy with expected output', function() {
+            expectExecutionToHaveExpectedOutput('good/typesynonym');
+        });
         it('option_monad.roy with expected output', function() {
             expectExecutionToHaveExpectedOutput('good/option_monad');
         });

--- a/test/fixtures/good/typesynonym.roy
+++ b/test/fixtures/good/typesynonym.roy
@@ -1,0 +1,6 @@
+type one = { field: String }
+
+type two = {
+   field: String
+}
+


### PR DESCRIPTION
I really want to write this:

```
type Whatever = {
  field1: Type1
  field2: Type2
  field3: Type3
  ...
  // 10 or so more fields
}
```

Happy to put commas in there if I must or put newlines in different places.

From the grammar, examples, and my experimentation, I cannot sort out how to format such a thing in a sane manner. How should I proceed?

It seems straightforward enough to modify the grammar, but I wonder if things are the way they are for a good reason.
