### PR TITLE
Add some basic type parser tests

### DIFF
--- a/test/TypeParserSpec.js
+++ b/test/TypeParserSpec.js
@@ -1,0 +1,80 @@
+describe('compiler', function(){
+    var jison = require('jison'),
+        typegrammar = require('../src/typegrammar'),
+        typeinference = require('../src/typeinference'),
+        types = require('../src/types'),
+        lexer = require('../src/lexer'),
+        nodes = require('../src/nodes').nodes;
+    
+    typegrammar.startSymbol = 'oneType';
+    typegrammar.bnf.oneType = [['type EOF', 'return $1;']];
+
+    typeparser = new jison.Parser(typegrammar, { debug: true, noDefaultResolve: true });
+
+    typeparser.yy = nodes
+
+    typeparser.lexer =  {
+        "lex": function() {
+            var token = this.tokens[this.pos] ? this.tokens[this.pos++] : ['EOF'];
+            if ( token[2] != this.yylineno ) {
+                this.column = 0
+            } else {
+                this.column += token[1].length;
+            }
+
+            this.yytext = token[1];
+            this.yylineno = token[2];
+            return token[0];
+        },
+        "setInput": function(tokens) {
+            this.tokens = tokens;
+            this.pos = 0;
+            this.column = 0;
+        },
+        "upcomingInput": function() {
+            return "";
+        },
+        "showPosition": function() {
+            return 'column: ' + this.column;
+        }
+    };
+
+    function parsedType(s) {
+        var tokens = lexer.tokenise(s);
+        var v = typeparser.parse(tokens);
+        return typeinference.nodeToType(v, {}, {});
+    }
+
+    function expectEqualTypes(subject, target) {
+        // FIXME: Use intentional equality once it is implemented
+        expect(subject.toString()).toEqual(target.toString());
+    }
+    
+    it('should parse atomic types', function() {
+        expectEqualTypes( parsedType('Number'), new types.NumberType() );
+        expectEqualTypes( parsedType('Boolean'),new types.BooleanType() );
+        expectEqualTypes( parsedType('String'), new types.StringType() );
+    });
+    
+    it('should parse object types', function() {
+        expectEqualTypes( parsedType('{}'), new types.ObjectType({}) );
+        expectEqualTypes( parsedType('{foo:String}'), new types.ObjectType({foo: new types.StringType()}) );
+
+        expectEqualTypes( parsedType('{foo:String, baz:Number}'),
+                          new types.ObjectType({
+                              foo: new types.StringType(), 
+                              baz: new types.NumberType()
+                          }));
+        // TODO: expectEqualTypes( parsedType('{\n\tfoo:String\n}'), new types.ObjectType({foo: new types.StringType()}) );
+    });
+
+    it('should parse function types', function() {
+        expectEqualTypes( parsedType('Function(String, String)'),
+                          new types.FunctionType([new types.StringType(), new types.StringType()]) );
+    });
+
+    it('should parse array types', function() {
+        expectEqualTypes( parsedType('[Number]'),
+                          new types.ArrayType(new types.NumberType()) );
+    });
+});


### PR DESCRIPTION
Hello,

In order to more easily isolate parsing failures when editing the grammar, I thought I would begin a test suite just for the type parser. This is just a skeleton but I hope it is useful anyhow.

Notes and limitations:
- I did not find intentional equality on types in the codebase, so I used `toString()` which is obviously fragile and must be replaced in the long term.
- I just mimicked the parser creation from `compile.js` but am not entirely sure what that's about. Is it because it would take a layer of indirection from the generated parser to encapsulate the extra lexing logic?
- I would love to express all of these tests as the property `identity == parse . pretty` in a QuickCheck-like framework (like I did [here](https://github.com/inkling/scala-relaxng/blob/master/src/test/scala/ParsePrettySpec.scala#L65)).
  - We would need to choose/write such a framework. (I've had some success with [killdream/claire](http://github.com/killdream/claire) but could see wanting to avoid a LiveScript dependency and/or create something that just directly mirrors QuickCheck and SmallCheck's concepts.)
  - And create a generator for an arbitrary type, which is easy and almost always worthwhile.
  - This property, along with just a few regression tests, is great for ensuring the health of a parser without having mountains of test cases to modify whenever you make a change to the language.
  
  \- Kenn
