### PR TITLE
Empty file should not be treated as missing

### DIFF
--- a/src/node-repl.js
+++ b/src/node-repl.js
@@ -19,34 +19,25 @@ var getSandbox = function() {
 
 var getFileContents = function(filename) {
     var fs = require('fs'),
-        exts = ["", ".roy", ".lroy"],
-        filenames = _.map(exts, function(ext){
-            return filename + ext;
-        }),
-        foundFilename,
-        source,
-        err,
-        i;
+        filenames,
+        foundFilename;
 
-    // Check to see if an extension is specified, if so, don't bother
-    // checking others
-    if (/\..+$/.test(filename)) {
-        source = fs.readFileSync(filename, 'utf8');
-        filenames = [filename];
-    } else {
-        foundFilename = _.find(filenames, function(filename) {
-            return fs.existsSync(filename);
-        });
-        if(foundFilename) {
-            source = fs.readFileSync(foundFilename, 'utf8');
-        }
+    filenames = /\..+$/.test(filename) ? // if an extension is specified,
+                [filename] :             // don't bother checking others
+                _.map(["", ".roy", ".lroy"], function(ext){
+                    return filename + ext;
+                });
+
+    foundFilename = _.find(filenames, function(filename) {
+        return fs.existsSync(filename);
+    });
+
+    if(foundFilename) {
+        return fs.readFileSync(foundFilename, 'utf8');
     }
-
-    if(!source) {
+    else {
         throw new Error("File(s) not found: " + filenames.join(", "));
     }
-
-    return source;
 };
 
 var colorLog = function(color) {


### PR DESCRIPTION
An empty file (i.e., file contents == "") was being treated as missing when trying to
compile it. This is undesirable, and should not cause an error at all, as the empty string
is a valid Roy program. The cause of this was the empty string being interpreted as falsy
in `if(!source)`.

This patch refactors the getFileContents function to fix this. It also tidies a few things,
e.g. removing unused variables.
